### PR TITLE
Missing translation for vest locks

### DIFF
--- a/apps/web/public/locales/zh-CN.json
+++ b/apps/web/public/locales/zh-CN.json
@@ -181,7 +181,7 @@
   "Use Vesting": "启用缓释",
   "Starting Date:": "开始日期：",
   "Unlock Date:": "解锁日期：",
-  "Ending Date:": "结束日期：",
+  "Ending Date": "结束日期",
   "Lock #": "锁 #",
   "Lock with id": "锁 ID 为",
   "Viewing": "正在查看",


### PR DESCRIPTION
Now I have access to token list locally, I identified a missing translation when creating vest locks.