### PR TITLE
lang specific Wiki link

### DIFF
--- a/apps/web/src/components/Menu/config/config.ts
+++ b/apps/web/src/components/Menu/config/config.ts
@@ -270,7 +270,7 @@ const config: (
         },
         {
           label: t('Wiki'),
-          href: 'https://wiki.icecreamswap.com',
+          href: languageCode === 'zh-cn' ? 'https://wiki.icecreamswap.com/v/zh' : 'https://wiki.icecreamswap.com',
           type: DropdownMenuItemType.EXTERNAL_LINK,
         },
         // {


### PR DESCRIPTION
When the language code is 'zh-cn', use the Chinese Wiki link, otherwise use the English one.