### PR TITLE
fix: add missing build dep

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -26,6 +26,7 @@
       "outputs": []
     },
     "dev": {
+      "dependsOn": ["@pancakeswap/next-config#build"],
       "cache": false,
       "persistent": true
     },


### PR DESCRIPTION
Currently it's not possible to run the site in dev mode, without building it prior.

See: https://github.com/pancakeswap/pancake-frontend/commit/ac6ef44db880b1689a0669d82719d58996da3ca1