### PR TITLE
fix: kyc breaks without a wallet connection

### DIFF
--- a/apps/web/src/views/Kyc/index.tsx
+++ b/apps/web/src/views/Kyc/index.tsx
@@ -47,7 +47,7 @@ export const Kyc: React.FC = () => {
   const { address, status } = useAccount()
   const token = useToken(chain.kyc?.feeToken)
   const addTransaction = useTransactionAdder()
-  const tokenContract = useERC20(token.address)
+  const tokenContract = useERC20(token?.address)
   const paid = useSWR(
     address ? `kyc/${address}` : null,
     async () => {


### PR DESCRIPTION
when there is no wallet connection the returned token becomes undefined, which then, if you try to access any fields, will result in the page breaking