### PR TITLE
translation for WCORE (v2 -> v3)

### DIFF
--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -3031,5 +3031,8 @@
   "Unwrap": "解包",
   "LP rewards: %percent%% trading fees, distributed proportionally among LP token holders.": "LP 奖励：%percent%% 的交易费，按比例分配给 LP 代币持有者。",
   "Currently %feature% is only supported on": "目前 %feature% 仅支持以下区块链网络",
+  "It looks like you still use our old WCORE. Simply unwrap it by": "看起来您仍在使用我们的旧版 WCORE。只需通过",
+  "\"swapping\"": "\"兑换\"",
+  "it to CORE.": "解包成 CORE。",
   "Chinese": "中文"
 }


### PR DESCRIPTION
It looks like you still use our old WCORE. Simply unwrap it by swapping it to CORE.
-> 
看起来您仍在使用我们的旧版 WCORE。只需通过 "兑换" 解包成 CORE。


